### PR TITLE
fix: support localized slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ given entity on your site. You can sub in any field on the entity using the $fie
 
 ![JSON field screenshot](https://github.com/novemberfiveco/datocms-plugin-nextjs-sidebar-preview-button/blob/master/docs/field.png?raw=true)
 
+> If you use Next.js [Internationalized Routing](https://nextjs.org/docs/advanced-features/i18n-routing), make sure to enable localization on the JSON field. Routes will be prefixed with the locale from the CMS, e.g. /en/blog/$slug.
+
 ## Preview Links
 
 Once you've configured the plugin and added the field to a model, you will be able to see it as a sidebar widget.
@@ -34,7 +36,7 @@ The query params on the API preview path are not configurable, and are based on 
 
 ## Development
 
-If you want to develop on this extension, the quickest way is to run `yarn start` and manually install it by going to Settings > Plugins,
+If you want to develop on this extension, the quickest way is to run `npm start` and manually install it by going to Settings > Plugins,
 clicking the add button, and clicking "create a private one" in the lower right. Give it:
 
 - A name of your choosing
@@ -49,3 +51,4 @@ Important changes:
 - Updated to use datocms-plugin v2 framework
 - Fixed bugs with single instances.
 - Remove exit preview button
+- Fixed bugs with localization

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "datocms-plugin-nextjs-sidebar-preview-button",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "datocms-plugin-nextjs-sidebar-preview-button",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "datocms-plugin-sdk": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datocms-plugin-nextjs-sidebar-preview-button",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage": "https://github.com/novemberfiveco/datocms-plugin-nextjs-sidebar-preview-button",
   "description": "A Datocms plugin to add a preview button to the sidebar of a model",
   "license": "MIT",

--- a/src/entrypoints/PreviewLink.tsx
+++ b/src/entrypoints/PreviewLink.tsx
@@ -8,10 +8,27 @@ interface Props {
   ctx: RenderFieldExtensionCtx;
 }
 
-const replaceVariables = (entityPath: string, attributes: ItemAttributes) => {
+const replaceVariables = (
+  entityPath: string,
+  attributes: ItemAttributes,
+  locale: string | null,
+) => {
   let path = entityPath ?? '';
   Object.entries(attributes).forEach(([field, value]) => {
-    path = path.replace(`$${field}`, value as string);
+    if (path.includes(`$${field}`)) {
+      let localizedValue: string;
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        locale !== null &&
+        locale in value
+      ) {
+        localizedValue = (value as any)[locale];
+      } else {
+        localizedValue = value as string;
+      }
+      path = path.replace(`$${field}`, localizedValue);
+    }
   });
   return path;
 };
@@ -27,7 +44,7 @@ export default function PreviewLink({ ctx }: Props) {
   const attributes = useMemo(() => ctx.item?.attributes ?? {}, [ctx.item]);
 
   const previewHref = useMemo(() => {
-    const path = replaceVariables(entityPath, attributes);
+    const path = replaceVariables(entityPath, attributes, locale);
     const noSlashInstanceUrl = siteUrl.replace(/\/$/, '');
 
     return [


### PR DESCRIPTION
Hi 👋 

This PR adds support for localized slugs. When you enable localization on a slug, the value becomes `{ en: 'about', fr: 'a-propos-de-nous' }` instead of a plain string, so it used to be converted to  `[Object object]`. 


There are many NextJS sidebar preview button plugins, but none of the seem the support this case 🤷 